### PR TITLE
Added subtitles to the guidelines-for-bbs page.

### DIFF
--- a/docs/guidelines-for-bbs.md
+++ b/docs/guidelines-for-bbs.md
@@ -15,38 +15,49 @@ provides s GovStack-compliant API and transparently accesses the externally depl
 At the core, the Sandbox deployment environment for building blocks is a basic Kubernetes cluster. Building blocks deployed inside the Sandbox are not directly exposed to the public Internet.
 
 ## General guidelines
-* Building block applications should be provided as one or more OCI compliant container images (“Docker images”) and
-packaged using a Helm (version 3) chart that defines the resources required by the application.
 
-* * For example, if the application uses a database, the deployment should define one. 
+### OCI compliant container images
+Building block applications should be provided as one or more OCI compliant container images (“Docker images”).
 
-* The chart should define a minimal, small scale deployment for exploration and development, covering only the essential
+### Helm Chart
+Container(s) of the application  should be packaged using a Helm (version 3) chart that defines the resources required by
+the application. The chart should define a minimal, small scale deployment for exploration and development, covering only the essential
 components and functionality.
 
-* The deployment should only depend on basic Kubernetes concepts and abstractions (e.g. deployments, pods, config maps,
+* * For example, if the application uses a database, the deployment should define one.
+
+### Basic Kubernetes concepts
+The deployment should only depend on basic Kubernetes concepts and abstractions (e.g. deployments, pods, config maps,
 secrets, services, persistent volume claims).
 
-* The application should be isolated into a Kubernetes namespace. The namespace name should be configurable during the
+### Kubernetes Namespace
+The application should be isolated into a Kubernetes namespace. The namespace name should be configurable during the
 chart install time.
 
-* An application can not expect control of the cluster, and should not depend on advanced features like custom Kubernetes
+### Do not expect control of the cluster
+An application can not expect control of the cluster, and should not depend on advanced features like custom Kubernetes
 controllers.
 
-* The application should not expose any interfaces (e.g. ingresses should be opt-in or disabled).
+### Not Expose any interfaces
+The application should not expose any interfaces (e.g. ingresses should be opt-in or disabled).
 
-* The application should not, in general, require access to external resources in the Internet, but it can use other 
+### No external dependencies
+The application should not, in general, require access to external resources in the Internet, but it can use other 
 building blocks deployed in the same Sandbox.
 
-* _Configurable_: The deployment should include means for providing initial configuration for the application. For example, 
+### Configurable deployment
+The deployment should include means for providing initial configuration for the application. For example, 
 the application can provide additional configuration APIs, read configuration provided via a ConfigMap at deployment 
  time, or the configuration can be (partially) baked in to the container images. The exact mechanism is implementation 
- specific, but should be scriptable (not require manual steps or using an UI).
+ specific, but should be scriptable (not require manual steps or using a UI).
 
-* _Automatic deployment_: The deployment should be fully automated so that the deployment can be triggered e.g. from a
+### Automatic deployment
+The deployment should be fully automated so that the deployment can be triggered e.g. from a
 CI/CD pipeline. Installing the chart with possible additional deployment-time configuration should start the application
 in a known, working state.
 
-* * Preferably, the deployment should include basic tests that can be used to verify a successful deployment, and it
+### Tests
+Preferably, the deployment should include basic tests that can be used to verify a successful deployment, and it
 should be possible to integrate the tests to the pipeline.
 
 ## Examples


### PR DESCRIPTION
We created a drat [pain point page](https://govstack-global.atlassian.net/wiki/spaces/DEMO/pages/252346369/Pain+point+onboarding+BB+in+sandbox). We described the case with S3 bucket and payment hub.
We found that having sub titles in the guideline page is very helpful. They allow  to precise pinpoint to a particular requirement.
